### PR TITLE
Remove accommodation made for ruby 2.7 that causes it to not work wit…

### DIFF
--- a/lib/active_interactor/organizer/interactor_interface.rb
+++ b/lib/active_interactor/organizer/interactor_interface.rb
@@ -93,7 +93,7 @@ module ActiveInteractor
 
         interactor = interactor_class.new(context)
         env = ActiveSupport::Callbacks::Filters::Environment.new(interactor, false, nil)
-        deferred_after_perform_callbacks.compile(nil).invoke_after(env)
+        deferred_after_perform_callbacks.compile.invoke_after(env)
         interactor.send(:context)
       end
 


### PR DESCRIPTION
Remove accommodation made for ruby 2.7 that causes it to not work with our ruby 3.1.4 application