### PR TITLE
Fix dual call issue with interactors with deferred after_performs

### DIFF
--- a/lib/active_interactor/organizer/interactor_interface.rb
+++ b/lib/active_interactor/organizer/interactor_interface.rb
@@ -121,7 +121,7 @@ module ActiveInteractor
         return unless deferred_after_perform_callbacks.present?
 
         deferred_after_perform_callbacks.each do |callback|
-          interactor_class.skip_callback(:perform, :after, callback.filter, raise: false)
+          interactor_class.skip_callback(:perform, :after, callback.filter, raise: false, if: -> { self.options.organizer.present? })
         end
       end
 

--- a/spec/integration/an_organizer_with_interactor_with_after_callbacks_deferred_spec.rb
+++ b/spec/integration/an_organizer_with_interactor_with_after_callbacks_deferred_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'An organizer with after callbacks deferred', type: :integration 
 
       after_perform do
         context.steps << 'after_perform_1a'
+        context.called_test_after_perform = true
       end
 
       after_perform do
@@ -16,6 +17,7 @@ RSpec.describe 'An organizer with after callbacks deferred', type: :integration 
       end
 
       def perform
+        context.fail! if context.should_fail
         context.steps = []
         context.steps << 'perform_1'
       end
@@ -57,6 +59,8 @@ RSpec.describe 'An organizer with after callbacks deferred', type: :integration 
       organize TestInteractor1, TestInteractor2, TestInteractor3
     end
   end
+  
+  let(:organizer) { interactor_class }
 
   include_examples 'a class with interactor methods'
   include_examples 'a class with interactor callback methods'
@@ -146,6 +150,56 @@ RSpec.describe 'An organizer with after callbacks deferred', type: :integration 
           'after_perform_3a',
         ]
       )}
+    end
+
+    context 'when interactor is called via organizer' do
+      context 'and interactor is called individually prior' do
+        it 'calls the after_perform callbacks in both cases' do
+          result = test_interactor_1.perform
+          expect(result).to be_success
+          expect(result.called_test_after_perform).to be(true)
+ 
+          result = organizer.perform
+          expect(result).to be_success
+          expect(result.called_test_after_perform).to be(true)
+        end
+
+        context 'and interactor fails when called individually' do
+          it 'calls the after_perform callbacks just when organized' do
+            result = test_interactor_1.perform(should_fail: true)
+            expect(result).to be_failure
+            expect(result.called_test_after_perform).to be_nil
+  
+            result = organizer.perform
+            expect(result).to be_success
+            expect(result.called_test_after_perform).to be(true)
+          end
+        end
+      end
+
+      context 'and interactor is called individually after' do
+        it 'calls the after_perform callbacks in both cases' do
+          result = organizer.perform
+          expect(result).to be_success
+          expect(result.called_test_after_perform).to be(true)
+
+          result = test_interactor_1.perform
+          expect(result).to be_success
+          expect(result.called_test_after_perform).to be(true)
+        end
+
+        context 'and interactor fails when called individually' do
+          it 'calls the after_perform callbacks just when organized' do
+            result = organizer.perform
+            expect(result).to be_success
+            expect(result.called_test_after_perform).to be(true)
+
+            result = test_interactor_1.perform(should_fail: true)
+            expect(result).to be_failure
+            expect(result.called_test_after_perform).to be_nil
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

<!-- Summarize the pull request -->
Fix dual call issue with interactors with deferred after_performs

If an Interactor that has deferred after_performs is called from an Organizer and then...later...directly, the after_performs are skipped when calling directly.

This is due to how Organizers handle Interactors with deferred logic. In such a case, the Organizer modifies the Interactor's callback so that it is skipped. However, this does not account for cases where an Interactor is called both as part of an Organizer and on it's own. In this case, the Interactor believes it should skip handling the after_performs forever, and rely instead on the Organizer to call them at the appropriate time.

This change updates the logic so that the callback is only skipped if the organizer property is not present. This property is used to tell the Interactor that and by what it is being "organized".

## Information

- ~[ ] Contains Documentation~
- [x] Contains Tests
- ~[ ] Contains Breaking Changes~

### Fixed

- Issue where calling Interactor with deferred after_callbacks as part of an Organizer, and then later on its own...results in the after_perform callbacks being skipped the second time.
